### PR TITLE
Add initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+
+os:
+  - linux
+  - osx
+
+compiler:
+  - gcc
+
+matrix:
+  allow_failures:
+    - os: osx
+
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,10 @@ XCODE_PROJ := Space\ Invaders
 OSX_EXECUTABLE := ./$(XCODE_PROJ)/Build/Products/Debug/$(XCODE_PROJ).app/Contents/MacOS/$(XCODE_PROJ)
 OSX_RUN_CMD := $(OSX_EXECUTABLE)
 
+CFLAGS := -ggdb -g --std=c99 # -Wall -Wextra
 ifdef DEBUG
-    CFLAGS = -D DEBUG -ggdb --std=c99
+    CFLAGS += -D DEBUG
     OSX_RUN_CMD := lldb $(OSX_EXECUTABLE)
-else
-    CFLAGS = -ggdb -g # -Wall -Wextra
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OSX_EXECUTABLE := ./$(XCODE_PROJ)/Build/Products/Debug/$(XCODE_PROJ).app/Content
 OSX_RUN_CMD := $(OSX_EXECUTABLE)
 
 ifdef DEBUG
-    CFLAGS = -D DEBUG -ggdb
+    CFLAGS = -D DEBUG -ggdb --std=c99
     OSX_RUN_CMD := lldb $(OSX_EXECUTABLE)
 else
     CFLAGS = -ggdb -g # -Wall -Wextra


### PR DESCRIPTION
Add basic .travis.yml to ensure that the test target passes until a more complicated build can be setup (like #6).